### PR TITLE
README.md: Add more supported cards to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ At this point receive and send PSP traffic succesfully through XLink Kai using t
 - Intel Centrino Wireless-N 1000 (iwlwifi)
 - Intel Centrino Advanced-N 6205 (iwlwifi)
 - Intel Pro Wireless 5100 AGN (iwlwifi)
+- Intel® Wi-Fi 6E AX210 (Gig +) (iwlwifi)
 
 ### Ralink
 - TP-Link TL-WN727N v1 (Ralink rt3070 (rt2800usb))
 - WTXUP Ralink RT3070 (rt2800usb)
 - TOOGOO®/SODIAL® Mini 150Mbps USB WiFi Wireless LAN 802.11 n/g/b Netzwerk Adapter Ralink RT5370 (rt2800usb)
 - Planex GW-US54Mini2 (Ralink rt2501usb (rt73))
+- Linksys WUSB600N v1 Dual-Band Wireless-N Network Adapter Ralink RT2870 (rt2800usb)
 
 ### Realtek
 - Hercules Guillemot HWGUm-54 (rtl8192su (codedwrench/rtl8192su))

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ At this point receive and send PSP traffic succesfully through XLink Kai using t
 - TP-Link TL-WDN4800 (Atheros AR93xx (ath9k))
 - NetGear, Inc. WNA1100 Wireless-N 150 (Atheros 9271 (ath9k_htc))
 - TP-Link TL-WN821N v3 (Atheros 9287 (ath9k_htc))
+- Qualcomm Atheros QCA6164 802.11ac Wireless Network Adapter (ath9k_pci)
 
 ### Broadcom
 - Dell Wireless 1390 (Broadcom BCM4311 (b43)) with the following patch: https://gist.github.com/codedwrench/8d7916d63993574e1dd089a62dd523a9

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ At this point receive and send PSP traffic succesfully through XLink Kai using t
 - TP-Link TL-WDN4800 (Atheros AR93xx (ath9k))
 - NetGear, Inc. WNA1100 Wireless-N 150 (Atheros 9271 (ath9k_htc))
 - TP-Link TL-WN821N v3 (Atheros 9287 (ath9k_htc))
-- Qualcomm Atheros QCA6164 802.11ac Wireless Network Adapter (ath9k_pci)
+- Qualcomm Atheros QCA6164 802.11ac Wireless Network Adapter (ath10k_pci)
 
 ### Broadcom
 - Dell Wireless 1390 (Broadcom BCM4311 (b43)) with the following patch: https://gist.github.com/codedwrench/8d7916d63993574e1dd089a62dd523a9


### PR DESCRIPTION
I've tested and verified both of these cards work with XLHA and can play psp games in plugin mode, and use monitor mode.

The intel card works as it supports all older connections all the way back to wifi 4 see [here](https://www.intel.com/content/www/us/en/products/docs/wireless/wi-fi-6e-ax210-module-brief.html)