### PR TITLE
build.yml: Merge Unit Tests into main build environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,31 +24,17 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake gcc-10 g++-10 libboost-dev libboost-program-options-dev libncurses5-dev libpcap-dev libpthread-stubs0-dev libnl-3-dev libnl-genl-3-dev libnl-nf-3-dev
+          sudo apt-get install -y cmake gcc-10 g++-10 libboost-dev libboost-program-options-dev libncurses5-dev libpcap-dev libpthread-stubs0-dev libnl-3-dev libnl-genl-3-dev libnl-nf-3-dev libgtest-dev libgmock-dev
       - name: Build
         run: |
-          mkdir build && cd build && cmake .. && cmake --build . -- -j`nproc`
+          mkdir build && cd build && cmake .. -DENABLE_TESTS=1 && cmake --build . -- -j`nproc`
+      - name: Unit Tests
+        run: |
+          cd build
+          ./tests
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: XLHA-Debian
           path: build/xlinkhandheldassistant
           if-no-files-found: error
-
-  unittests:
-    name: Unit Tests
-    needs: ubuntu
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone Tree
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake gcc-10 g++-10 libboost-dev libboost-program-options-dev libncurses5-dev libpcap-dev libpthread-stubs0-dev libnl-3-dev libnl-genl-3-dev libnl-nf-3-dev libgtest-dev libgmock-dev
-      - name: Build & Run Unit Tests
-        run: |
-          mkdir build && cd build && cmake .. -DENABLE_TESTS=1 && cmake --build . -- -j`nproc`
-          ./tests


### PR DESCRIPTION
Originally, I was hesitant to do merge Unit Tests into the main build environment, however seeing as it would make more sense to do this because a build shouldn't be downloadable unless the tests pass, and it cuts build time to under a minute, I don't see an issue with it